### PR TITLE
Add task status type. Fix #190

### DIFF
--- a/ClientApp/src/components/Home.tsx
+++ b/ClientApp/src/components/Home.tsx
@@ -93,6 +93,9 @@ const Home = (): JSX.Element => {
                 <div>
                   <TaskOutcome taskOutcomeCode={tle.taskOutcomeCode!} />
                 </div>
+                <div className="ml-3 w-25">
+                  <strong>{tle.taskCode}</strong>
+                </div>
                 <div className="ml-3">
                   <FormattedDate
                     date={tle.createdTs}


### PR DESCRIPTION
Add task status type to the homepage listing. Fix #190. Now appears like this:

<img width="685" alt="Screen Shot 2023-02-20 at 10 57 42 AM" src="https://user-images.githubusercontent.com/3538990/220181883-a1354d13-37c3-459e-8bc5-5df2af07f157.png">
