### PR TITLE
Update apiVersion in templates

### DIFF
--- a/openshift/api/bc-api.yaml
+++ b/openshift/api/bc-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/openshift/api/dc-api.yaml
+++ b/openshift/api/dc-api.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 objects:
   - apiVersion: v1
     kind: Service

--- a/openshift/frontend/bc-frontend.yaml
+++ b/openshift/frontend/bc-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/openshift/frontend/dc-frontend.yaml
+++ b/openshift/frontend/dc-frontend.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 objects:
   - apiVersion: v1
     kind: Service


### PR DESCRIPTION
The syntax for `apiVersion` needs to be updated to prevent CLI errors when deploying.